### PR TITLE
Added source insertion

### DIFF
--- a/CMakeClassCreator/ast.py
+++ b/CMakeClassCreator/ast.py
@@ -20,10 +20,6 @@ class VariableUseWithLocation(VariableUse, _LocationTrait):
         super().__init__(var_name)
         self.location = location
 
-    def is_same(self, other):
-        return isinstance(other, VariableUse) \
-                and self.var_name == other.var_name
-
     def get_location(self):
         return self.location
 

--- a/CMakeClassCreator/ast.py
+++ b/CMakeClassCreator/ast.py
@@ -1,4 +1,10 @@
 from CMakeClassCreator.parser import Parser
+from abc import ABC, abstractmethod
+
+class _LocationTrait(ABC):
+    @abstractmethod
+    def get_location(self):
+        pass
 
 ### AST components ###
 class VariableUse(object):
@@ -9,13 +15,33 @@ class VariableUse(object):
         return isinstance(other, VariableUse) \
                 and self.var_name == other.var_name
 
+class VariableUseWithLocation(VariableUse, _LocationTrait):
+    def __init__(self, var_name, location):
+        super().__init__(var_name)
+        self.location = location
+
+    def is_same(self, other):
+        return isinstance(other, VariableUse) \
+                and self.var_name == other.var_name
+
+    def get_location(self):
+        return self.location
+
 class ListItemString(object):
     def __init__(self, list_item_string):
         self.list_item_string = list_item_string
         
     def is_same(self, other):
         return isinstance(other, ListItemString) \
-                and self.list_item_string == other.list_item_string
+                and self.list_item_string == other.list_item_string 
+                
+class ListItemStringWithPosition(ListItemString, _LocationTrait):
+    def __init__(self, list_item_string, location):
+        super().__init__(list_item_string)
+        self.location = location
+
+    def get_location(self):
+        return self.location
 
 class CMakeStringList(object):
     def __init__(self, items):
@@ -75,10 +101,9 @@ class TargetSources(object):
                 and self.cmake_string_list.is_same(other.cmake_string_list)
 ### AST components END ###
 
-### Parse actions ###
 def _parse_standalone_variable_use_action(s, loc, toks):
     var_name = toks[1]
-    return VariableUse(var_name)
+    return VariableUseWithLocation(var_name, loc)
 
 def _parse_standalone_variable_use_in_quotes_action(s, loc, toks):
     return toks[1]
@@ -88,10 +113,9 @@ def _parse_variable_use_to_compose_list_item(s, loc, toks):
 
 def _parse_list_item_string_action(s, loc, toks):
     list_item_string = toks[0]
-    return ListItemString(list_item_string)
+    return ListItemStringWithPosition(list_item_string, loc)
 
 def _parse_cmake_string_list_action(s, loc, toks):
-    toks = [item if not isinstance(item, str) else ListItemString(item) for item in toks]
     return CMakeStringList(toks)
 
 def _parse_set_normal_variable_action(s, loc, toks):
@@ -112,11 +136,9 @@ def _parse_add_normal_executable_action(s, loc, toks):
 def _parse_target_sources_action(s, loc, toks):
     target_name = toks[2]
     cmake_string_list = CMakeStringList([])
-    for scoped_cmake_string_list in [tok for tok in toks if isinstance(tok, CMakeStringList)]:
-            cmake_string_list.items += scoped_cmake_string_list.items 
+    for scoped_cmake_string_list in [tok for tok in list(toks) if isinstance(tok, CMakeStringList)]:
+            cmake_string_list.items += list(scoped_cmake_string_list.items) 
     return TargetSources(target_name, cmake_string_list)
-
-### Parse actions END ###
 
 class Ast(object):
     """

--- a/CMakeClassCreator/source_inserter.py
+++ b/CMakeClassCreator/source_inserter.py
@@ -29,7 +29,7 @@ class _SingleCMakeListAstTrait(ABC):
     def get_cmake_list_ast(self):
         pass
 
-class __SingleCmakeListInserter(_SourceInsertTrait, _SingleCMakeListAstTrait):
+class __SingleCMakeListInserter(_SourceInsertTrait, _SingleCMakeListAstTrait):
     def __init__(self, cmake_string_list):
         self.cmake_string_list = cmake_string_list
 
@@ -40,7 +40,7 @@ class __SingleCmakeListInserter(_SourceInsertTrait, _SingleCMakeListAstTrait):
         position = _get_position_after_last_list_item(self.cmake_string_list)
         return InsertAction(position, " " + source_item)
 
-class _AddLibraryInserter(_TargetNameTrait, __SingleCmakeListInserter):
+class _AddLibraryInserter(_TargetNameTrait, __SingleCMakeListInserter):
     def __init__(self, add_library_ast):
         super().__init__(add_library_ast.cmake_string_list)
         self.add_library_ast = add_library_ast
@@ -48,7 +48,7 @@ class _AddLibraryInserter(_TargetNameTrait, __SingleCmakeListInserter):
     def get_name(self):
         return self.add_library_ast.library_name
 
-class _AddExecutableInserter(_TargetNameTrait, __SingleCmakeListInserter):
+class _AddExecutableInserter(_TargetNameTrait, __SingleCMakeListInserter):
     def __init__(self, add_executable_ast):
         super().__init__(add_executable_ast.cmake_string_list)
         self.add_executable_ast = add_executable_ast
@@ -56,12 +56,12 @@ class _AddExecutableInserter(_TargetNameTrait, __SingleCmakeListInserter):
     def get_name(self):
         return self.add_executable_ast.executable_name
 
-class _SetNormalVariableInserter(__SingleCmakeListInserter):
+class _SetNormalVariableInserter(__SingleCMakeListInserter):
     def __init__(self, set_normal_variable_ast):
         super().__init__(set_normal_variable_ast.cmake_string_list)
         self.set_normal_variable_ast = set_normal_variable_ast
 
-class _TargetSourcesInserter(_TargetNameTrait, __SingleCmakeListInserter):
+class _TargetSourcesInserter(_TargetNameTrait, __SingleCMakeListInserter):
     def __init__(self, target_sources_ast):
         super().__init__(target_sources_ast.cmake_string_list)
         self.target_sources_ast = target_sources_ast

--- a/CMakeClassCreator/source_inserter.py
+++ b/CMakeClassCreator/source_inserter.py
@@ -1,0 +1,206 @@
+import CMakeClassCreator.ast as ast
+from abc import ABC, abstractmethod
+
+class SourceInserterException(Exception):
+    pass
+
+class InsertAction(object):
+    def __init__(self, position, content):
+        self.position = position
+        self.content = content
+
+    def do(self, full_cmake_source):
+        content_before = full_cmake_source[:self.position-1]
+        content_after = full_cmake_source[self.position-1:]
+        return content_before + self.content + content_after
+
+class _SourceInsertTrait(ABC):
+    @abstractmethod
+    def insert_source(self, source_item):
+        pass
+
+class _TargetNameTrait(ABC):
+    @abstractmethod
+    def get_name(self, cmake_ast):
+        pass
+
+class _SingleCMakeListAstTrait(ABC):
+    @abstractmethod
+    def get_cmake_list_ast(self):
+        pass
+
+class __SingleCmakeListInserter(_SourceInsertTrait, _SingleCMakeListAstTrait):
+    def __init__(self, cmake_string_list):
+        self.cmake_string_list = cmake_string_list
+
+    def get_cmake_list_ast(self):
+        return self.cmake_string_list
+
+    def insert_source(self, source_item):
+        position = _get_position_after_last_list_item(self.cmake_string_list)
+        return InsertAction(position, " " + source_item)
+
+class _AddLibraryInserter(_TargetNameTrait, __SingleCmakeListInserter):
+    def __init__(self, add_library_ast):
+        super().__init__(add_library_ast.cmake_string_list)
+        self.add_library_ast = add_library_ast
+
+    def get_name(self):
+        return self.add_library_ast.library_name
+
+class _AddExecutableInserter(_TargetNameTrait, __SingleCmakeListInserter):
+    def __init__(self, add_executable_ast):
+        super().__init__(add_executable_ast.cmake_string_list)
+        self.add_executable_ast = add_executable_ast
+
+    def get_name(self):
+        return self.add_executable_ast.executable_name
+
+class _SetNormalVariableInserter(__SingleCmakeListInserter):
+    def __init__(self, set_normal_variable_ast):
+        super().__init__(set_normal_variable_ast.cmake_string_list)
+        self.set_normal_variable_ast = set_normal_variable_ast
+
+class _TargetSourcesInserter(_TargetNameTrait, __SingleCmakeListInserter):
+    def __init__(self, target_sources_ast):
+        super().__init__(target_sources_ast.cmake_string_list)
+        self.target_sources_ast = target_sources_ast
+
+    def get_name(self):
+        return self.target_sources_ast.target_name
+
+def _get_position_after_last_list_item(cmake_string_list_ast):
+    last_item = cmake_string_list_ast.items[-1]
+    return last_item.location + 1 + len(last_item.list_item_string)
+
+def insert_source_item_directly_in_target(cmake_ast, source_item, cmake_target):
+    """ Sets up the action to add a source file directly to the add_{library|executable} statement of a given target """
+    inserter = _make_inserter_for_target(cmake_ast, cmake_target)
+    return inserter.insert_source(source_item)
+
+def _make_inserter_for_target(cmake_ast, cmake_target):
+    add_library_ast_items = [ast_item for ast_item in _get_all_library_targets(cmake_ast) if ast_item.library_name == cmake_target]
+    add_executable_ast_items = [ast_item for ast_item in _get_all_executable_targets(cmake_ast) if ast_item.executable_name == cmake_target]
+
+    inserters = [_AddLibraryInserter(add_library_ast) for add_library_ast in add_library_ast_items]
+    inserters += [_AddExecutableInserter(add_executable_ast) for add_executable_ast in add_executable_ast_items]
+
+    if len(inserters) == 0:
+        raise SourceInserterException("The target {} is not found in the given cmake ast".format(cmake_target))
+
+    if len(inserters) > 1:
+        raise SourceInserterException("There are too many add_{executable, library} statements for target {}".format(cmake_target))
+
+    return inserters[0]
+
+def _get_all_library_targets(cmake_ast):
+    return [ast_item for ast_item in cmake_ast if isinstance(ast_item, ast.AddLibrary)]
+
+def _get_all_executable_targets(cmake_ast):
+    return [ast_item for ast_item in cmake_ast if isinstance(ast_item, ast.AddExecutable)]
+
+def insert_source_item_in_variable_from_target(cmake_ast, source_item, cmake_target, variable_name):
+    """ Sets up the action to add a source file to the given variable of the given target """
+    target_inserter = _make_inserter_for_target(cmake_ast, cmake_target)
+    relevant_variable_declarations_in_target = [declaration for declaration in target_inserter.get_cmake_list_ast().items if isinstance(declaration, ast.VariableUse) and declaration.var_name == variable_name]
+
+    if len(relevant_variable_declarations_in_target) == 0:
+        raise SourceInserterException("The variable {0} is not used in target {1}".format(variable_name, cmake_target))
+
+    variable_inserter = _make_inserter_for_variable_declaration(cmake_ast, variable_name)
+    return variable_inserter.insert_source(source_item)
+
+def insert_source_item_in_variable(cmake_ast, source_item, variable_name):
+    """ Sets up the action to add a source file to the given variable
+
+    Does the same thing as insert_source_item_in_variable_from_target without asserting the source belongs to a target
+    """
+    inserter = _make_inserter_for_variable_declaration(cmake_ast, variable_name)
+    return inserter.insert_source(source_item)
+
+def _make_inserter_for_variable_declaration(cmake_ast, variable_name):
+    set_normal_variable_ast_items = _find_all_variable_declarations(cmake_ast)
+
+    inserters = [_SetNormalVariableInserter(declaration) for declaration in set_normal_variable_ast_items if declaration.var_name == variable_name]
+    
+    if len(inserters) == 0:
+        raise SourceInserterException("The variable declaration {} is not found in the given cmake ast".format(variable_name))
+
+    if len(inserters) > 1:
+        raise SourceInserterException("There is more than one variable declaration statements with variable name {}".format(variable_name))
+
+    return inserters[0]
+
+def _find_all_variable_declarations(cmake_ast):
+    return [ast_item for ast_item in cmake_ast if isinstance(ast_item, ast.SetNormalVariable)]
+
+def insert_source_item_next_to_other_source(cmake_ast, source_item, reference_item):
+    """ Sets up the action to add a source file in the same way as the reference source file
+
+    The reference source file should already exist in the cmake source
+    """
+    try:
+        target = _find_reference_directly_in_target_declaration(cmake_ast, reference_item)
+        inserter =  _AddLibraryInserter(target) if isinstance(target, ast.AddLibrary) else _AddExecutableInserter(target)
+        return inserter.insert_source(source_item)
+    except SourceInserterException:
+        pass
+
+    try:
+        declaration = _find_reference_in_variable_declaration(cmake_ast, reference_item)
+        return _SetNormalVariableInserter(declaration).insert_source(source_item)
+    except SourceInserterException:
+        pass
+
+    try:
+        target_sources_stmt = _find_reference_in_target_sources_stmt(cmake_ast, reference_item)
+        return _TargetSourcesInserter(target_sources_stmt).insert_source(source_item)
+    except SourceInserterException:
+        pass
+
+    raise SourceInserterException("The reference item {} is not declared in any (supported) cmake statement".format(reference_item))
+
+
+def _find_reference_directly_in_target_declaration(cmake_ast, reference_item):
+    all_targets = _get_all_library_targets(cmake_ast) + _get_all_executable_targets(cmake_ast)
+    cmake_lists_with_target = [(target.cmake_string_list, target) for target in all_targets]
+    relevant_cmake_lists_with_target = [cmake_lists_with_target for cmake_lists_with_target in cmake_lists_with_target if _contains_source_item(cmake_lists_with_target[0], reference_item)]
+
+    if len(relevant_cmake_lists_with_target) == 0:
+        raise SourceInserterException("The reference item {} is not declared in a target".format(reference_item))
+    if len(relevant_cmake_lists_with_target) > 1:
+        raise SourceInserterException("The reference item {0} is defined in multiple targets: {1}".format(reference_item, \
+            [cmake_list_with_target[0] for cmake_list_with_target in cmake_lists_with_target]))
+
+    return relevant_cmake_lists_with_target[0][1]
+
+def _find_reference_in_variable_declaration(cmake_ast, reference_item):
+    relevant_variable_declarations = [declaration for declaration in cmake_ast if isinstance(declaration, ast.SetNormalVariable) \
+        and _contains_source_item(declaration.cmake_string_list, reference_item)]
+    
+    if len(relevant_variable_declarations) == 0:
+        raise SourceInserterException("The reference item {} is not declared in a variable declaration".format(reference_item))
+    if len(relevant_variable_declarations) > 1:
+        raise SourceInserterException("The reference item {0} is defined in multiple variable declarations: {1}".format(reference_item, \
+            [declaration.var_name for declaration in relevant_variable_declarations]))
+
+    return relevant_variable_declarations[0]
+
+def _find_reference_in_target_sources_stmt(cmake_ast, reference_item):
+    relevant_target_sources = [target_sources_stmt for target_sources_stmt in cmake_ast if isinstance(target_sources_stmt, ast.TargetSources) \
+        and _contains_source_item(target_sources_stmt.cmake_string_list, reference_item)]
+    
+    if len(relevant_target_sources) == 0:
+        raise SourceInserterException("The reference item {} is not declared in a target_sources statement".format(reference_item))
+    if len(relevant_target_sources) > 1:
+        raise SourceInserterException("The reference item {0} is defined in multiple target_sources statements: {1}".format(reference_item, \
+            ["target_sources({})".format(target_sources_stmt.target_name) for target_sources_stmt in relevant_target_sources]))
+
+    return relevant_target_sources[0]
+
+def _contains_source_item(cmake_string_list, source_item):
+    try:
+        next(list_item for list_item in cmake_string_list.items if isinstance(list_item, ast.ListItemString) and list_item.list_item_string == source_item)
+        return True
+    except StopIteration:
+        return False

--- a/Test/test_Parser.py
+++ b/Test/test_Parser.py
@@ -13,16 +13,14 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(list(result), ["#", "This is a comment, here's some garbage 34857039(*&)(**&%*&$%$#`~"])
 
     def test_normal_set_stmt(self):
-        givenStringVarContent = ("\n${some_other_var}\n"
+        givenString = ("set(var\n" 
+            + "${some_other_var}\n"
             + "cool_class.h\n"
             + "# The parser should skip these commented tokens: PARENT_SCOPE, ) \n"
             + '" and tokens between double quotes are not actual tokens: PARENT_SCOPE, )" \n'
             + '"${using_variables_should_work_between_quotes_though}" \n'
-            + "cool_class.cpp")
-
-        givenString = ("set(var"
-            + givenStringVarContent
-            + "\n)")
+            + "cool_class.cpp\n"
+            + ")")
 
         givenParser = Parser()
 
@@ -136,6 +134,21 @@ class ParserTest(unittest.TestCase):
 
         givenString = ("target_sources(TabsPls PRIVATE a.cpp b.cpp c.cpp PUBLIC pub_a.cpp pub_b.cpp pub_c.cpp\n"
                 + "INTERFACE interface.hpp)")
+
+        result = givenParser._target_sources_stmt.parseString(givenString)
+        self.assertEqual(list(result), ["target_sources", "(", "TabsPls", "PRIVATE", "a.cpp", "b.cpp", "c.cpp", "PUBLIC", "pub_a.cpp", "pub_b.cpp", "pub_c.cpp", "INTERFACE", "interface.hpp", ")"])
+
+    def test_target_sources_with_extra_whitespacing_stmt(self):
+        givenParser = Parser()
+
+        givenString = ("target_sources(TabsPls\n"
+            + "PRIVATE\n"
+            + "a.cpp b.cpp c.cpp\n"
+            + "PUBLIC\n"
+            + "pub_a.cpp pub_b.cpp pub_c.cpp\n"
+            + "INTERFACE\n"
+            + "interface.hpp\n"
+            + ")")
 
         result = givenParser._target_sources_stmt.parseString(givenString)
         self.assertEqual(list(result), ["target_sources", "(", "TabsPls", "PRIVATE", "a.cpp", "b.cpp", "c.cpp", "PUBLIC", "pub_a.cpp", "pub_b.cpp", "pub_c.cpp", "INTERFACE", "interface.hpp", ")"])

--- a/Test/test_Source_inserter.py
+++ b/Test/test_Source_inserter.py
@@ -1,0 +1,118 @@
+
+import unittest
+
+import context
+
+from CMakeClassCreator import source_inserter, ast
+
+class TestSourceInserter(unittest.TestCase):
+    def test_get_position_after_last_list_item(self):
+        #This is based entirely on the last item's location
+        given_cmake_string_list = ast.CMakeStringList([ast.ListItemStringWithPosition("item1.cpp", -1), ast.VariableUseWithLocation("Sources", -1), ast.ListItemStringWithPosition("item2", 14)])
+        self.assertEqual(source_inserter._get_position_after_last_list_item(given_cmake_string_list), 20)
+        
+
+    def test_insert_directly_in_executable(self):
+        given_ast = ast.Ast()
+        given_source = "add_executable(TabsPls Main.cpp)"
+        given_cmake_ast = given_ast.parse(given_source)
+        insert_action = source_inserter.insert_source_item_directly_in_target(given_cmake_ast, "file.cpp", "TabsPls")
+        self.assertEqual(insert_action.position, 32)
+        self.assertEqual(insert_action.content, " file.cpp")
+        self.assertEqual(insert_action.do(given_source), "add_executable(TabsPls Main.cpp file.cpp)")
+
+    def test_insert_directly_in_non_existing_executable(self):
+        given_ast = ast.Ast()
+        given_cmake_ast = given_ast.parse("add_executable(IWantTabs Main.cpp)")
+        self.assertRaises(source_inserter.SourceInserterException, source_inserter.insert_source_item_directly_in_target, given_cmake_ast, "file.cpp", "TabsPls")
+
+    def test_insert_in_variable_from_target(self):
+        given_ast = ast.Ast()
+        given_source = ("set(TabsPls_Sources Main.cpp)\n"
+            + "add_executable(TabsPls ${TabsPls_Sources})")
+        given_cmake_ast = given_ast.parse(given_source)
+
+        insert_action = source_inserter.insert_source_item_in_variable_from_target(given_cmake_ast, "file.cpp", "TabsPls", "TabsPls_Sources")
+        self.assertEqual(insert_action.position, 29)
+        self.assertEqual(insert_action.content, " file.cpp")
+        self.assertEqual(insert_action.do(given_source), "set(TabsPls_Sources Main.cpp file.cpp)\nadd_executable(TabsPls ${TabsPls_Sources})")
+
+    def test_insert_in_non_existing_variable_from_target(self):
+        given_ast = ast.Ast()
+        given_cmake_ast = given_ast.parse(("set(TabsPls_Sources Main.cpp)\n"
+            + "add_executable(TabsPls OtherMain.cpp")) 
+
+        self.assertRaises(source_inserter.SourceInserterException, source_inserter.insert_source_item_in_variable_from_target, given_cmake_ast, "file.cpp", "TabsPls", "TabsPls_Sources")
+
+    def test_insert_in_variable_from_non_existing_target(self):
+        given_ast = ast.Ast()
+        given_cmake_ast = given_ast.parse(("set(IWantTabs_Sources Main.cpp)\n"
+            + "add_executable(IWantTabs ${IWantTabs_Sources}")) 
+
+        self.assertRaises(source_inserter.SourceInserterException, source_inserter.insert_source_item_in_variable_from_target, given_cmake_ast, "file.cpp", "TabsPls", "IWantTabs_Sources")
+        
+    def test_insert_in_variable(self):
+        given_ast = ast.Ast()
+        given_source = ("set(TabsPls_Sources Main.cpp)\n"
+            + "add_executable(TabsPls ${TabsPls_Sources})")
+        given_cmake_ast = given_ast.parse(given_source)
+
+        insert_action = source_inserter.insert_source_item_in_variable(given_cmake_ast, "file.cpp", "TabsPls_Sources")
+        self.assertEqual(insert_action.position, 29)
+        self.assertEqual(insert_action.content, " file.cpp")
+        self.assertEqual(insert_action.do(given_source), ("set(TabsPls_Sources Main.cpp file.cpp)\n"
+            + "add_executable(TabsPls ${TabsPls_Sources})"))
+
+
+    def test_insert_in_non_existing_variable(self):
+        given_ast = ast.Ast()
+        given_cmake_ast = given_ast.parse(("set(IWantTabs_Sources Main.cpp)\n"
+            + "add_executable(TabsPls OtherMain.cpp")) 
+
+        self.assertRaises(source_inserter.SourceInserterException, source_inserter.insert_source_item_in_variable, given_cmake_ast, "file.cpp", "TabsPls_Sources")
+
+    def test_insert_next_to_other_source_directly_at_target(self):
+        given_ast = ast.Ast()
+        given_source = "add_executable(TabsPls Main.cpp)"
+        given_cmake_ast = given_ast.parse(given_source)
+
+        insert_action = source_inserter.insert_source_item_next_to_other_source(given_cmake_ast, "file.cpp", "Main.cpp")
+        self.assertEqual(insert_action.position, 32)
+        self.assertEqual(insert_action.content, " file.cpp")
+        self.assertEqual(insert_action.do(given_source), "add_executable(TabsPls Main.cpp file.cpp)")
+
+    def test_insert_next_to_other_source_in_variable_set(self):
+        given_ast = ast.Ast()
+        given_source = ("set(TabsPls_Sources Main.cpp)\n"
+            + "add_executable(TabsPls ${TabsPls_Sources})")
+        given_cmake_ast = given_ast.parse(given_source)
+
+        insert_action = source_inserter.insert_source_item_next_to_other_source(given_cmake_ast, "file.cpp", "Main.cpp")
+        self.assertEqual(insert_action.position, 29)
+        self.assertEqual(insert_action.content, " file.cpp")
+        self.assertEqual(insert_action.do(given_source), "set(TabsPls_Sources Main.cpp file.cpp)\nadd_executable(TabsPls ${TabsPls_Sources})")
+    
+    def test_insert_next_to_other_source_in_target_sources_stmt(self):
+        given_ast = ast.Ast()
+        given_source = ("set(TabsPls_Sources Main.cpp)\n"
+            + "add_executable(TabsPls ${TabsPls_Sources})\n"
+            + "target_sources(TabsPls PRIVATE file1.cpp)")
+        given_cmake_ast = given_ast.parse(given_source)
+
+        insert_action = source_inserter.insert_source_item_next_to_other_source(given_cmake_ast, "file2.cpp", "file1.cpp")
+        self.assertEqual(insert_action.position, 114)
+        self.assertEqual(insert_action.content, " file2.cpp")
+        self.assertEqual(insert_action.do(given_source), \
+            ("set(TabsPls_Sources Main.cpp)\n"
+            + "add_executable(TabsPls ${TabsPls_Sources})\n"
+            + "target_sources(TabsPls PRIVATE file1.cpp file2.cpp)"))
+
+    def test_insert_next_to_non_existing_other_source(self):
+        given_ast = ast.Ast()
+        given_cmake_ast = given_ast.parse("add_executable(TabsPls Main.cpp)") 
+
+        self.assertRaises(source_inserter.SourceInserterException, source_inserter.insert_source_item_next_to_other_source, given_cmake_ast, "file.cpp", "other_file.cpp")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
a source item can now be added to cmake source
the current api allows:
* adding directly to an add_{executable, library} statement
* adding to a variable, with or without validating the relevant target
* adding in the same place as an existing source item